### PR TITLE
os:cmd instead of Erlang ports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ script:
   - rebar3 xref
   - rebar3 dialyzer
   - rebar3 lint
+  - rebar3 fmt
   - rebar3 ct

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: erlang
+
+otp_release:
+   - 19.3
+   - 20.3
+   - 21.3
+   - 22.3
+   - 23.0
+
+script:
+  - rebar3 --version
+  - rebar3 xref
+  - rebar3 dialyzer
+  - rebar3 lint
+  - rebar3 ct

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ script:
   - rebar3 lint
   - rebar3 fmt
   - rebar3 ct
+  - rebar3 cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ script:
   - rebar3 as test xref
   - rebar3 as test dialyzer
   - rebar3 lint
-  - rebar3 fmt
+  #- rebar3 fmt
   - rebar3 ct
   - rebar3 cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ otp_release:
 
 script:
   - rebar3 --version
-  - rebar3 xref
-  - rebar3 dialyzer
+  - rebar3 as test xref
+  - rebar3 as test dialyzer
   - rebar3 lint
   - rebar3 fmt
   - rebar3 ct

--- a/README.md
+++ b/README.md
@@ -1,40 +1,56 @@
-rebar_cmd
-=====
-Run custom shell commands as rebar3 tasks.
+# rebar_cmd
 
-### Purpose
+Run custom shell commands with `rebar3 cmd <command>`.
 
-The goal of this plugin is to allow additional commands to rebar3 so that one can use it to manage everything in an Erlang project.
+## Purpose
 
-Wether it is bringing docker containers up, tagging a new release on git or deleting log files, we should be able to use the same build tool for all of that.
+The goal of this plugin is to allow `rebar3` to run additional commands, so
+that one can use it solely to manage everything in an Erlang project.
 
-### How it works
+Whether it is bringing Docker containers up, tagging a new Git release or
+deleting log files, you should be able to use a single build tool.
 
-This is a very simple and straight forward plugin. Simply tell rebar a list of commands to execute (just like linux aliases) and access them via `rebar3 cmd <your command>`
+## How it works
 
+This is a very simple and straightforward plugin. Simply describe your
+command in `rebar.config` and execute (just like you would Linux aliases)
+with `rebar3 cmd <command>`.
 
-### Usage
+## Usage
 
+Add the plugin to your `rebar.config`:
 
-Add the plugin to your rebar.config:
 ```erlang
     {plugins, [
-      {rebar_cmd, "0.2.6"}
+        {rebar_cmd, "0.2.6"}
     ]}.
 
     {commands, [
-        { docker_up, "docker-compose up -d" },
-        { sync, "git fetch upstream && git merge upstream/master" }
+        {docker_up, "docker-compose up -d"},
+        {sync, "git fetch upstream && git merge upstream/master"}
     ]}.
 ```
-In this case, we've added a command to bring our docker containers up, and another to sync the git repository with the remote master.
 
-Then you just have to call your plugin directly in an existing application:
+The example above shows you how to describe a command to bring your
+Docker containers up, as well as another one to sync a Git repository
+with remote master.
 
-```
-$ rebar3 cmd docker_up
-===> Fetching rebar_cmd
+Some options are available, as described below:
+
+* `[{timeout, <Ms>}]` (defaults to `15000`)
+* `[{verbose, <Verbose>}]` (defaults to `false`)
+
+e.g. you could change the previous `docker_up` command to have it fail
+after 5s with `{docker_up, "docker-compose up -d", [{timeout, 5000}]},`.
+You could also get more info from the shell for the above command
+`sync` with
+`{sync, "git fetch upstream && git merge upstream/master", [{verbose, true}]}`
+
+Check it out:
+
+```erlang
+$ rebar3 cmd sync
+===> Analyzing applications...
 ===> Compiling rebar_cmd
-<Command Output will be here>
+===> Command sync resulted in: "Already up to date."
 ```
-

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You could also get more info from the shell for the above command
 
 Check it out:
 
-```erlang
+```bash
 $ rebar3 cmd sync
 ===> Analyzing applications...
 ===> Compiling rebar_cmd

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,6 @@
 
 {dialyzer, [
     {warnings, [
-        unknown,
         unmatched_returns,
         error_handling,
         underspecs

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
-{plugins, [rebar3_hex, erlfmt, rebar3_lint]}.
+{plugins, [rebar3_hex, rebar3_lint]}.
 
 {erlfmt, [
     write,
@@ -28,5 +28,8 @@
         {erl_opts, [nowarn_export_all]},
         {cover_enabled, true},
         {cover_opts, [verbose]}
+    ]},
+    {fmt, [
+        {plugins, [erlfmt]}
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
-{plugins, [rebar3_hex, erlfmt]}.
+{plugins, [rebar3_hex, erlfmt, rebar3_lint]}.
 
 {erlfmt, [
     write,
@@ -7,3 +7,19 @@
 ]}.
 
 {deps, []}.
+
+{dialyzer, [
+    {warnings, [
+        unknown,
+        unmatched_returns,
+        error_handling,
+        underspecs
+    ]}
+]}.
+
+{xref_checks, [
+    exports_not_used,
+    undefined_function_calls,
+    locals_not_used,
+    deprecated_function_calls
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -22,3 +22,11 @@
     locals_not_used,
     deprecated_function_calls
 ]}.
+
+{profiles, [
+    {test, [
+        {erl_opts, [nowarn_export_all]},
+        {cover_enabled, true},
+        {cover_opts, [verbose]}
+    ]}
+]}.

--- a/src/rebar_cmd.app.src
+++ b/src/rebar_cmd.app.src
@@ -1,5 +1,5 @@
 {application, rebar_cmd,
- [{description, "Run custom shell commands as rebar3 tasks"},
+ [{description, "Run custom shell commands with rebar3 cmd <command>"},
   {vsn, "0.2.6"},
   {registered, []},
   {application,

--- a/src/rebar_cmd.app.src
+++ b/src/rebar_cmd.app.src
@@ -11,5 +11,5 @@
 
   {maintainers, ["Sasan Hezarkhani", "Matheus Mendes", "Ahmad Mokhtar"]},
   {licenses, ["MIT"]},
-  {links, [{"Github", "https://github.com/shezarkhani/rebar_cmd"}]}
+  {links, [{"Github", "https://github.com/gootik/rebar_cmd"}]}
  ]}.

--- a/src/rebar_cmd.app.src
+++ b/src/rebar_cmd.app.src
@@ -2,7 +2,7 @@
  [{description, "Run custom shell commands with rebar3 cmd <command>"},
   {vsn, git},
   {registered, []},
-  {application,
+  {applications,
    [kernel,
     stdlib
    ]},

--- a/src/rebar_cmd.app.src
+++ b/src/rebar_cmd.app.src
@@ -1,6 +1,6 @@
 {application, rebar_cmd,
  [{description, "Run custom shell commands with rebar3 cmd <command>"},
-  {vsn, git},
+  {vsn, "0.2.6"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/rebar_cmd.app.src
+++ b/src/rebar_cmd.app.src
@@ -1,6 +1,6 @@
 {application, rebar_cmd,
  [{description, "Run custom shell commands with rebar3 cmd <command>"},
-  {vsn, "0.2.6"},
+  {vsn, git},
   {registered, []},
   {application,
    [kernel,

--- a/src/rebar_cmd.erl
+++ b/src/rebar_cmd.erl
@@ -1,6 +1,7 @@
 -module(rebar_cmd).
 
 -export([init/1]).
+-ignore_xref([init/1]).
 
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->

--- a/src/rebar_cmd.erl
+++ b/src/rebar_cmd.erl
@@ -1,6 +1,7 @@
 -module(rebar_cmd).
 
 -export([init/1]).
+
 -ignore_xref([init/1]).
 
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.

--- a/src/rebar_cmd_prv.erl
+++ b/src/rebar_cmd_prv.erl
@@ -5,6 +5,7 @@
     do/1,
     format_error/1
 ]).
+
 -ignore_xref([
     do/1,
     format_error/1

--- a/src/rebar_cmd_prv.erl
+++ b/src/rebar_cmd_prv.erl
@@ -13,6 +13,20 @@
 
 -define(PROVIDER, cmd).
 -define(DEPS, [app_discovery]).
+-define(DEFAULT_OPT_TIMEOUT, 15000).
+-define(DEFAULT_OPT_VERBOSE, false).
+
+-ifdef(TEST).
+-export([
+    do_internal/2,
+    find_command_in/2
+]).
+
+-ignore_xref([
+    do_internal/2,
+    find_command_in/2
+]).
+-endif.
 
 %% ===================================================================
 %% Public API
@@ -35,17 +49,8 @@ init(State) ->
 do(State) ->
     Config = rebar_state:get(State, commands, []),
     {ArgsPropList, _} = rebar_state:command_parsed_args(State),
-    {task, CmdName} = proplists:lookup(task, ArgsPropList),
-    case lists:keyfind(list_to_atom(CmdName), 1, Config) of
-        {_, Command} ->
-            rebar_api:debug("Running ~p with command ~p.~n", [[CmdName], [Command]]),
-            case run_shell({CmdName, Command}) of
-                {ok, _} -> {ok, State};
-                {error, Error} -> {error, Error}
-            end;
-        false ->
-            {error, "Command " ++ CmdName ++ " is unknown. Check your configuration."}
-    end.
+    CmdName = proplists:get_value(task, ArgsPropList, undefined),
+    do_internal({CmdName, find_command_in(CmdName, Config)}, State).
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->
@@ -54,35 +59,78 @@ format_error(Reason) ->
 %% ===================================================================
 %% Private API
 %% ===================================================================
-run_shell({CmdName, Command}) ->
-    run_shell({CmdName, Command}, 15000).
 
-run_shell({CmdName, Command}, Timeout) ->
-    Port = erlang:open_port({spawn, Command}, [exit_status]),
-    shell_loop(Port, [], Timeout, {CmdName, Command}).
+do_internal({_CmdName, CmdDef}, _State) when
+    is_tuple(CmdDef) andalso
+        (erlang:tuple_size(CmdDef) < 2 orelse erlang:tuple_size(CmdDef) > 3)
+->
+    {error, "Invalid configuration: expected [{CmdName, Cmd, Opts}]."};
+do_internal({_CmdName, CmdDef}, State) when is_tuple(CmdDef) ->
+    {CmdName, Cmd, Opts} = normalize(CmdDef),
+    handle_cmd(exec(CmdName, Cmd, Opts), Opts, State);
+do_internal({undefined = _CmdName, false = _CommandFound}, _State) ->
+    {error, "No <command> (as in 'cmd <command>') given as input."};
+do_internal({CmdName, false = _CommandFound}, _State) ->
+    {error, "Command " ++ CmdName ++ " (as atom) is unknown. Check your configuration."}.
 
-shell_loop(Port, Data, Timeout, {CmdName, Command}) ->
+find_command_in(undefined = _CmdName, _Config) ->
+    false;
+find_command_in(CmdName, Config) ->
+    lists:keyfind(list_to_atom(CmdName), 1, Config).
+
+normalize({CmdName, Cmd}) ->
+    normalize({CmdName, Cmd, []});
+normalize({CmdName, Cmd, Opts}) ->
+    {atom_to_list(CmdName), Cmd, Opts}.
+
+exec(CmdName, Cmd, Opts) ->
+    Pid = self(),
+    Ref = erlang:make_ref(),
+    Timeout = get_opt(timeout, Opts, CmdName),
+    {MonitorPid, MonitorRef} = erlang:spawn_monitor(
+        fun() ->
+            not is_list(Cmd) andalso exit("call not expressed as a string"),
+            rebar_api:debug("Command ~s executing ~s with options ~p.", [CmdName, Cmd, Opts]),
+            Pid ! {Ref, os:cmd(Cmd)}
+        end
+    ),
     receive
-        {Port, {data, MoreData}} ->
-            shell_loop(Port, MoreData ++ Data, Timeout, {CmdName, Command});
-        {Port, {exit_status, 0}} ->
-            {ok, Data};
-        {Port, {exit_status, Error}} ->
-            Cmd = lists:flatten(Command),
-            {error,
-                "Command " ++
-                    CmdName ++
-                    " (" ++
-                    Cmd ++
-                    ") failed with exit status " ++
-                    integer_to_list(Error) ++ "."}
+        {Ref, Result} ->
+            {ok, {CmdName, Result}};
+        {'DOWN', MonitorRef, _Type, _Object, Info} ->
+            rebar_api:error("Command ~s died unexpectedly with ~p.", [CmdName, Info]),
+            {ok, {CmdName, died}}
     after Timeout ->
-        Cmd = lists:flatten(Command),
-        {error,
-            "Command " ++
-                CmdName ++
-                " (" ++
-                Cmd ++
-                ") timed out after " ++
-                integer_to_list(Timeout) ++ " ms."}
+        exit(MonitorPid, kill),
+        TimeOutS = integer_to_list(Timeout),
+        {error, "Command " ++ CmdName ++ " (" ++ Cmd ++ ") timed out after " ++ TimeOutS ++ " ms."}
     end.
+
+handle_cmd({error, Error}, _Opts, _State) ->
+    {error, Error};
+handle_cmd({ok, {_CmdName, died}}, _Opts, State) ->
+    {ok, State};
+handle_cmd({ok, {CmdName, Result}}, Opts, State) ->
+    case get_opt(verbose, Opts, CmdName) of
+        true ->
+            rebar_api:warn("Command ~s resulted in: ~p", [CmdName, Result]);
+        false ->
+            rebar_api:debug("Command ~s resulted in: ~p", [CmdName, Result])
+    end,
+    {ok, State}.
+
+get_opt(timeout, Opts, CmdName) ->
+    Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_OPT_TIMEOUT),
+    case is_integer(Timeout) of
+        false ->
+            rebar_api:error(
+                "Command ~s's timeout not expressed as an integer. "
+                "Defaulting to ~p.",
+                [CmdName, ?DEFAULT_OPT_TIMEOUT]
+            ),
+            ?DEFAULT_OPT_TIMEOUT;
+        true ->
+            Timeout
+    end;
+get_opt(verbose, Opts, _CmdName) ->
+    proplists:get_value(verbose, Opts, ?DEFAULT_OPT_VERBOSE).

--- a/src/rebar_cmd_prv.erl
+++ b/src/rebar_cmd_prv.erl
@@ -5,6 +5,10 @@
     do/1,
     format_error/1
 ]).
+-ignore_xref([
+    do/1,
+    format_error/1
+]).
 
 -define(PROVIDER, cmd).
 -define(DEPS, [app_discovery]).

--- a/src/rebar_cmd_prv.erl
+++ b/src/rebar_cmd_prv.erl
@@ -38,10 +38,10 @@ init(State) ->
         {module, ?MODULE},
         {bare, true},
         {deps, ?DEPS},
-        {example, "rebar3 cmd COMMAND"},
+        {example, "rebar3 cmd <command>"},
         {opts, []},
-        {short_desc, "A rebar plugin for running custom commands"},
-        {desc, "A rebar plugin for running custom commands."}
+        {short_desc, "A rebar3 plugin to run custom shell commands 'cmd <command>'."},
+        {desc, "A rebar3 plugin to run custom shell commands 'cmd <command>'"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 

--- a/src/rebar_cmd_prv.erl
+++ b/src/rebar_cmd_prv.erl
@@ -8,7 +8,12 @@
 
 -ignore_xref([
     do/1,
-    format_error/1
+    format_error/1,
+    {rebar_api, debug, 2},
+    {rebar_api, error, 2},
+    {rebar_api, warn, 2},
+    {rebar_state, add_provider, 2},
+    {providers, create, 1}
 ]).
 
 -define(PROVIDER, cmd).

--- a/src/rebar_cmd_prv.erl
+++ b/src/rebar_cmd_prv.erl
@@ -63,7 +63,6 @@ run_shell({CmdName, Command}, Timeout) ->
 shell_loop(Port, Data, Timeout, {CmdName, Command}) ->
     receive
         {Port, {data, MoreData}} ->
-            io:format(MoreData),
             shell_loop(Port, MoreData ++ Data, Timeout, {CmdName, Command});
         {Port, {exit_status, 0}} ->
             {ok, Data};

--- a/src/rebar_cmd_prv.erl
+++ b/src/rebar_cmd_prv.erl
@@ -98,8 +98,7 @@ exec(CmdName, Cmd, Opts) ->
         {Ref, Result} ->
             {ok, {CmdName, Result}};
         {'DOWN', MonitorRef, _Type, _Object, Info} ->
-            rebar_api:error("Command ~s died unexpectedly with ~p.", [CmdName, Info]),
-            {ok, {CmdName, died}}
+            {ok, {{CmdName, Info}, died}}
     after Timeout ->
         exit(MonitorPid, kill),
         TimeOutS = integer_to_list(Timeout),
@@ -108,7 +107,8 @@ exec(CmdName, Cmd, Opts) ->
 
 handle_cmd({error, Error}, _Opts, _State) ->
     {error, Error};
-handle_cmd({ok, {_CmdName, died}}, _Opts, State) ->
+handle_cmd({ok, {{CmdName, Info}, died}}, _Opts, State) ->
+    rebar_api:error("Command ~s died unexpectedly with ~p.", [CmdName, Info]),
     {ok, State};
 handle_cmd({ok, {CmdName, Result}}, Opts, State) ->
     case get_opt(verbose, Opts, CmdName) of

--- a/test/rebar_cmd_SUITE.erl
+++ b/test/rebar_cmd_SUITE.erl
@@ -1,0 +1,121 @@
+-module(rebar_cmd_SUITE).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-compile(export_all).
+
+-define(CONFIG, [
+    not_tuple,
+    {tuple_1},
+    {tuple_4, "ls", [], four},
+    {timeout_0, "ls", [{timeout, 0}]},
+    {timeout_1999, "sleep 2", [{timeout, 1999}]},
+    {non_verbose_ls, "ls", [{verbose, false}]},
+    {verbose_ls, "ls", [{verbose, true}]},
+    {not_string, 2},
+    {timeout_not_int, "ls", [{timeout, a}]},
+    {ok, "ls", [{timeout, 2500}, verbose]}
+]).
+
+all() ->
+    [
+        command_not_atom,
+        command_tuple_1,
+        command_tuple_4,
+        command_not_in_commands,
+        command_timeout_0,
+        command_timeout_1999,
+        command_verbose_false,
+        command_verbose_true,
+        command_not_string,
+        command_timeout_not_integer,
+        command_ok
+    ].
+
+command_not_atom(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(not_tuple, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {error, _},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_tuple_1(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(tuple_1, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {error, _},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_tuple_4(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(tuple_4, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {error, _},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_not_in_commands(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(not_in_commands, _FoundInSuiteConfig = false),
+    ?assertMatch(
+        {error, _},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_timeout_0(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(timeout_0, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {error, _},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_timeout_1999(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(timeout_1999, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {error, _},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_verbose_false(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(non_verbose_ls, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {ok, no_state},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_verbose_true(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(verbose_ls, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {ok, no_state},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_not_string(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(not_string, _FoundInSuiteConfig = true),
+    ?assertEqual(
+        {ok, no_state},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_timeout_not_integer(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(timeout_not_int, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {ok, no_state},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+command_ok(_Config) ->
+    {Cmd, CmdFound} = as_rebar3_cmd(ok, _FoundInSuiteConfig = true),
+    ?assertMatch(
+        {ok, no_state},
+        rebar_cmd_prv:do_internal({Cmd, CmdFound}, no_state)
+    ).
+
+%% Internal
+
+as_rebar3_cmd(Cmd, FoundInSuiteConfig) ->
+    FoundInSuiteConfig andalso
+        begin
+            true =
+                lists:keyfind(Cmd, 1, ?CONFIG) =/= false orelse
+                    lists:member(Cmd, ?CONFIG)
+        end,
+    {atom_to_list(Cmd), rebar_cmd_prv:find_command_in(atom_to_list(Cmd), ?CONFIG)}.


### PR DESCRIPTION
Attempting to [Fix #16] [Fix #21] [Fix #22], by replacing Erlang ports with `os:cmd` as discussed in two of the linked Issues.