### PR TITLE
Make output clearer and handle UTF-8

### DIFF
--- a/src/rebar_cmd_prv.erl
+++ b/src/rebar_cmd_prv.erl
@@ -12,6 +12,7 @@
     {rebar_api, debug, 2},
     {rebar_api, error, 2},
     {rebar_api, warn, 2},
+    {rebar_api, console, 2},
     {rebar_state, add_provider, 2},
     {providers, create, 1}
 ]).
@@ -115,12 +116,15 @@ handle_cmd({error, Error}, _Opts, _State) ->
 handle_cmd({ok, {{CmdName, Info}, died}}, _Opts, State) ->
     rebar_api:error("Command ~s died unexpectedly with ~p.", [CmdName, Info]),
     {ok, State};
-handle_cmd({ok, {CmdName, Result}}, Opts, State) ->
+handle_cmd({ok, {CmdName, RawResult}}, Opts, State) ->
+    Result = string:trim(RawResult),
     case get_opt(verbose, Opts, CmdName) of
         true ->
-            rebar_api:warn("Command ~s resulted in: ~p", [CmdName, Result]);
+            rebar_api:debug("Command ~s finished", [CmdName]),
+            rebar_api:console("~ts", [Result]);
         false ->
-            rebar_api:debug("Command ~s resulted in: ~p", [CmdName, Result])
+            rebar_api:debug("Command ~s finished", [CmdName]),
+            rebar_api:debug("Command ~s result: ~ts", [CmdName, Result])
     end,
     {ok, State}.
 


### PR DESCRIPTION
This PR improves the verbose command output, and makes both the verbose and debug output handle UTF-8 command output better. When running with verbose, the command output is printed directly to the shell instead of being put after an `warn` log.

## Example

First run is current `master`, second run is this PR:

<img width="440" alt="Screen Shot 2021-06-11 at 11 13 06" src="https://user-images.githubusercontent.com/112878/121663031-45d68280-caa6-11eb-9b8b-1cd97e1f7d2a.png">
